### PR TITLE
Leitura dos pulsos atrasada

### DIFF
--- a/Sensor Reading/Color Sensor- TCS3200/Two- Green-To Read.ino
+++ b/Sensor Reading/Color Sensor- TCS3200/Two- Green-To Read.ino
@@ -85,7 +85,7 @@ void color()
    
  //count OUT, pGreen, GREEN  
  
-  Right_green = pulseIn(Right_out, digitalRead(Right_out) == HIGH ? LOW : HIGH); 
-  Left_green = pulseIn(Left_out, digitalRead(Left_out) == HIGH ? LOW : HIGH);   
+  Right_green = pulseIn(Right_out, digitalRead(Right_out) == HIGH ? LOW : HIGH, 5000); 
+  Left_green = pulseIn(Left_out, digitalRead(Left_out) == HIGH ? LOW : HIGH, 5000);   
 }
 


### PR DESCRIPTION
Por padrão, o pulseIn utiliza 1 milhão microsegundos a cada leitura de pulso e isso atrasa todo o processo, se utilizar 5000 microsegundos / 5 milisegundos a leitura já agiliza muito!
https://www.arduino.cc/en/Reference/PulseIn